### PR TITLE
Change webpack back to only one NODE_ENV case

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,90 +7,19 @@ var Minimist = require('minimist');
 
 var BUILD_DIR = path.resolve(__dirname, 'dist');
 var APP_DIR = path.resolve(__dirname, '.');
-var DEFAULT_CONTEXT = '/mapreacter';
+var DEFAULT_CONTEXT = '/';
 
 var plugins = [
   new webpack.ProvidePlugin({
     'Intl': 'imports?this=>global!exports?global.Intl!intl'
   }),
-
+  new ExtractTextPlugin({ filename: 'css/[name].css', disable: false }),
+  new ExtractTextPlugin('css/sdk.css')
 ];
 var filename = '[name].js';
 var devtool= 'inline-source-map';
-if (process.env.NODE_ENV === "development") {
-  plugins.push(new webpack.DefinePlugin({ 'process.env': { 'NODE_ENV': JSON.stringify('development') } }));
-  plugins.push(new ExtractTextPlugin({ filename: 'css/[name].css', disable: false }));
-  plugins.push(new ExtractTextPlugin('css/sdk.css'));
-  filename = '[name].js';
-  devtool = '';
+var publicPath = "/dist/";
 
-  module.exports = {
-    entry: {
-      Client: [
-          APP_DIR + '/src/client.jsx',
-          APP_DIR + '/src/styles/less/client.less',
-      ],
-    },
-    output: {
-      path: BUILD_DIR,
-      filename: filename,
-      library: '[name]',
-      libraryTarget: 'umd',
-      umdNamedDefine: true,
-      publicPath: "/dist/"
-    },
-    devtool: devtool,
-    node: {fs: "empty"},
-    plugins: plugins,
-    resolve: {
-      extensions: ['.js', '.jsx']
-    },
-    module: {
-      loaders: [
-        {
-          test: /\.(js|jsx)$/,
-          loader: 'babel-loader',
-          exclude: /node_modules/
-        }, {
-          test: /\.css$/,
-          loader: "style-loader!css-loader"
-        }, {
-          test: /\.less$/,
-          use: ExtractTextPlugin.extract({
-            fallback: 'style-loader',
-            use: ['css-loader', {
-            loader: 'less-loader',
-            }],
-          }),
-        }, {
-          test: /\.json$/,
-          loader: "json-loader"
-        }, {
-          test: /\.(png|gif|jpg|jpeg|svg|otf|ttf|eot|woff)$/,
-          loader: 'file-loader'
-        }, {
-          test: /\.s?css$/,
-          use: ExtractTextPlugin.extract({
-            fallback: 'style-loader',
-            use: ['css-loader', {
-            loader: 'sass-loader',
-            options: {
-              includePaths: ['node_modules'],
-            }
-            }],
-          }),
-        }
-      ],
-      noParse: [/dist\/ol.js/, /dist\/jspdf.debug.js/]
-    },
-    externals: {
-      'cheerio': 'window',
-      'react/addons': true,
-      'react/lib/ExecutionEnvironment': true,
-      'react/lib/ReactContext': true
-    }
-  };
-}
 if (process.env.NODE_ENV === "production") {
   plugins.push(new webpack.DefinePlugin({ 'process.env': { 'NODE_ENV': JSON.stringify('production') } }));
   plugins.push(new ExtractTextPlugin({ filename: 'css/[name].min.css', disable: false }));
@@ -110,6 +39,7 @@ if (process.env.NODE_ENV === "production") {
           }));
   filename = '[name].min.js';
   devtool = '';
+  publicPath = _resolveBuildContext(DEFAULT_CONTEXT);
 
   function _resolveBuildContext(defaultContext) {
     // get context command line argument eg: "webpack --context=mapreacter"
@@ -120,71 +50,71 @@ if (process.env.NODE_ENV === "production") {
     }
     return context;
   }
-
-  module.exports = {
-    entry: {
-      Client: [
-          APP_DIR + '/src/client.jsx',
-          APP_DIR + '/src/styles/less/client.less',
-      ],
-    },
-    output: {
-      path: BUILD_DIR,
-      filename: filename,
-      library: '[name]',
-      libraryTarget: 'umd',
-      umdNamedDefine: true,
-      publicPath: _resolveBuildContext(DEFAULT_CONTEXT)
-    },
-    devtool: devtool,
-    node: {fs: "empty"},
-    plugins: plugins,
-    resolve: {
-      extensions: ['.js', '.jsx']
-    },
-    module: {
-      loaders: [
-        {
-          test: /\.(js|jsx)$/,
-          loader: 'babel-loader',
-          exclude: /node_modules/
-        }, {
-          test: /\.css$/,
-          loader: "style-loader!css-loader"
-        }, {
-          test: /\.less$/,
-          use: ExtractTextPlugin.extract({
-            fallback: 'style-loader',
-            use: ['css-loader', {
-            loader: 'less-loader',
-            }],
-          }),
-        }, {
-          test: /\.json$/,
-          loader: "json-loader"
-        }, {
-          test: /\.(png|gif|jpg|jpeg|svg|otf|ttf|eot|woff)$/,
-          loader: 'file-loader'
-        }, {
-          test: /\.s?css$/,
-          use: ExtractTextPlugin.extract({
-            fallback: 'style-loader',
-            use: ['css-loader', {
-            loader: 'sass-loader',
-            options: {
-              includePaths: ['node_modules'],
-            }
-            }],
-          }),
-        }
-      ],
-      noParse: [/dist\/ol.js/, /dist\/jspdf.debug.js/]
-    },
-    externals: {
-      'cheerio': 'window',
-      'react/addons': true,
-      'react/lib/ExecutionEnvironment': true,
-      'react/lib/ReactContext': true
-    }
-  };
 }
+
+module.exports = {
+  entry: {
+    Client: [
+        APP_DIR + '/src/styles/less/client.less',
+        APP_DIR + '/src/client.jsx',
+    ],
+  },
+  output: {
+    path: BUILD_DIR,
+    filename: filename,
+    library: '[name]',
+    libraryTarget: 'umd',
+    umdNamedDefine: true,
+    publicPath: publicPath
+  },
+  devtool: devtool,
+  node: {fs: "empty"},
+  plugins: plugins,
+  resolve: {
+    extensions: ['.js', '.jsx']
+  },
+  module: {
+    loaders: [
+      {
+        test: /\.(js|jsx)$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/
+      }, {
+        test: /\.css$/,
+        loader: "style-loader!css-loader"
+      }, {
+        test: /\.less$/,
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: ['css-loader', {
+          loader: 'less-loader',
+          }],
+        }),
+      }, {
+        test: /\.json$/,
+        loader: "json-loader"
+      }, {
+        test: /\.(png|gif|jpg|jpeg|svg|otf|ttf|eot|woff)$/,
+        loader: 'file-loader'
+      }, {
+        test: /\.s?css$/,
+        use: ExtractTextPlugin.extract({
+          fallback: 'style-loader',
+          use: ['css-loader', {
+          loader: 'sass-loader',
+          options: {
+            includePaths: ['node_modules'],
+          }
+          }],
+        }),
+      }
+    ],
+    noParse: [/dist\/ol.js/, /dist\/jspdf.debug.js/]
+  },
+  externals: {
+    'cheerio': 'window',
+    'react/addons': true,
+    'react/lib/ExecutionEnvironment': true,
+    'react/lib/ReactContext': true
+  }
+};


### PR DESCRIPTION
## What does this PR do?

Changes the webpack.config.js to it's original intend. Adding css stuff and changing order of the entry points.
### Changes
revert back to one module.export and only change variables for
production. otherwise leave the config as it for the default case
(development|test)
set DEFAULT_CONTEXT to / for less opinionated version